### PR TITLE
Samples: Add Hand-Eye Calibration samples and related procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ from the camera can be used.
               - [ReadPLY](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Applications/Basic/FileFormats/ReadPLY.hdev) - Import and display a Zivid point cloud from a PLY
                 file.
       - **Advanced**
+          - **HandEyeCalibration**
+              - [EyeInHandCalibration3DObject](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Applications/Advanced/HandEyeCalibration/EyeInHandCalibration3DObject.hdev) - Hand-eye calibration with a Zivid camera and a 3D
+                calibration object
+              - [EyeInHandCalibrationMVTecPlate](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Applications/Advanced/HandEyeCalibration/EyeInHandCalibrationMVTecPlate.hdev) - Hand-eye calibration with a Zivid camera and MVTec
+                calibration plate
+              - [JSONHomogeneousMatrixToHalconPose](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Applications/Advanced/HandEyeCalibration/JSONHomogeneousMatrixToHalconPose.hdev) - Transform homogenous matrixes to halcon pose
           - **ObjectMatching**
               - [SurfaceMatchingCreateModel](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Applications/Advanced/ObjectMatching/SurfaceMatchingCreateModel.hdev) - Create a model for HALCON surface-based 3D matching
                 algorithm from a Zivid point cloud captured by a camera.
@@ -66,6 +72,9 @@ from the camera can be used.
               - [SurfaceMatchingFindModelFromFile](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Applications/Advanced/ObjectMatching/SurfaceMatchingFindModelFromFile.hdev) - Utilize surface-based 3D matching on data taken with a
                 Zivid camera.
   - **Procedures**
+      - [calc\_calplate\_pose\_eye\_in\_hand](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Procedures/calc_calplate_pose_eye_in_hand.hdvp) - Calculate the pose of the calibration object in the camera frame for Eye-In-Hand.
+      - [calc\_calplate\_pose\_eye\_to\_hand](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Procedures/calc_calplate_pose_eye_to_hand.hdvp) - Calculate the pose of the calibration object in the camera frame for Eye-To-Hand.
+      - [generate\_R\_G\_B\_and\_RGB\_images](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Procedures/generate_R_G_B_and_RGB_images.hdvp) - Create separate images for each color channel and a combined RGB image.
       - [get\_first\_available\_zivid\_device](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Procedures/get_first_available_zivid_device.hdvp) - Get the first Zivid device from the input tuple of devices.
       - [get\_settings\_for\_zivid\_camera\_model](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Procedures/get_settings_for_zivid_camera_model.hdvp) - Get settings depending on the camera model.
       - [get\_zivid\_camera\_width](https://github.com/zivid/zivid-halcon-samples/tree/master/source/Procedures/get_zivid_camera_width.hdvp) - Get width for given camera and sampling pixel setting.

--- a/source/Applications/Advanced/HandEyeCalibration/EyeInHandCalibration3DObject.hdev
+++ b/source/Applications/Advanced/HandEyeCalibration/EyeInHandCalibration3DObject.hdev
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hdevelop file_version="1.2" halcon_version="25.11.0.0">
+    <procedure name="main">
+        <interface/>
+        <body>
+            <c>*</c>
+            <c>* Hand-eye calibration with a Zivid camera and a 3D calibration object</c>
+            <c>*</c>
+            <c>* This example explains how to use the hand-eye calibration for the case where</c>
+            <c>* a 3D camera is moving with the robot and the calibration</c>
+            <c>* object is stationary (Eye-In-Hand). The pose of a 3D model of a calibration</c>
+            <c>* object is determined in the scene using surface-based matching.</c>
+            <c>* To run this sample, you can download the dataset</c>
+            <c>* from https://support.zivid.com/en/latest/api-reference/samples/sample-data.html</c>
+            <c>*</c>
+            <c/>
+            <l>import './../../../Procedures'</l>
+            <c/>
+            <l>dev_update_off ()</l>
+            <l>get_zivid_sample_data_dir(ZividDataDir)</l>
+            <l>HalconZividSampleData := ZividDataDir + '/ZividHandEyeHalconData/'</l>
+            <c/>
+            <c>* Reading the initial values for the Zivid camera intrinsics </c>
+            <c>* Use either hard-coded camera intrinsics or intrinsics estimated from the point cloud (recommended)</c>
+            <c>* https://support.zivid.com/en/latest/reference-articles/camera-intrinsics.html</c>
+            <l>read_cam_par(HalconZividSampleData + 'estimated_intrinsics.dat', InputCameraParameters)</l>
+            <c/>
+            <c>* Setting path and reading a 3D object model from PLY file</c>
+            <l>PointCloudDir := HalconZividSampleData + 'CalibrationObjectPointClouds/'</l>
+            <l>RobotPosesDir := HalconZividSampleData + 'RobotPoses/'</l>
+            <l>ImageWidth := InputCameraParameters[11]</l>
+            <c/>
+            <c>* Reading the 3D object model from file.</c>
+            <c>* It can be any 3D object of your choice.</c>
+            <c>* This object model will serve as the calibration object.</c>
+            <l>read_object_model_3d (HalconZividSampleData + 'calibration_object.dxf', 1, [], [], OM3DModel, StatusReadCalibrationObject)</l>
+            <l>sample_object_model_3d (OM3DModel, 'fast', 0.0009, [], [], SampledObjectModel3DZremoved)</l>
+            <c/>
+            <c>* Removing the flat surface of the object to avoid matching a flat surface</c>
+            <l>select_points_object_model_3d (SampledObjectModel3DZremoved, 'point_coord_z', 0.0001, 'max', ObjectModel3DThresholded)</l>
+            <c/>
+            <c>* Prepare surface model for the surface matching algorithm</c>
+            <l>create_pose (0, 0, 0.5, 180, 0, 0, 'Rp+T', 'gba', 'point', Pose)</l>
+            <l>rigid_trans_object_model_3d (ObjectModel3DThresholded, Pose, ObjectModel3DRigidTrans)</l>
+            <l>triangulate_object_model_3d (ObjectModel3DRigidTrans, 'greedy', [], [], TriangulatedObjectModel3D, Information)</l>
+            <l>surface_normals_object_model_3d (TriangulatedObjectModel3D, 'triangles', [], [], ObjectModel3DNormals)</l>
+            <l>pose_invert (Pose, PoseInvert)</l>
+            <l>rigid_trans_object_model_3d (ObjectModel3DNormals, PoseInvert, ObjectModel3DRigidTransInvert)</l>
+            <l>create_surface_model (ObjectModel3DRigidTransInvert, 0.03, [], [], CalibrationObjectSurfaceModelID)</l>
+            <c/>
+            <c>* Setting windows parameters</c>
+            <l>dev_close_window ()</l>
+            <l>WindowWidth := 512</l>
+            <l>WindowHeight := 384</l>
+            <l>dev_open_window (0, WindowWidth + 10, WindowWidth, WindowHeight, 'black', ImageWindowHandle)</l>
+            <l>dev_open_window (0, 0, WindowWidth, WindowHeight, 'black', WindowHandle)</l>
+            <l>set_display_font (WindowHandle, 14, 'mono', 'true', 'false')</l>
+            <l>set_display_font (ImageWindowHandle, 14, 'mono', 'true', 'false')</l>
+            <l>Instruction := ['Rotate: Left button', 'Zoom:   Shift + left button', 'Move:   Ctrl  + left button']</l>
+            <l>dev_set_color ('green')</l>
+            <c/>
+            <l>Message := 'Surface model to be searched'</l>
+            <c>* Reducing the point density of the model for better visualization</c>
+            <l>sample_object_model_3d (OM3DModel, 'fast', 0.0009, [], [], SampledObjectModel3D)</l>
+            <l>visualize_object_model_3d (WindowHandle, SampledObjectModel3D, [], [], 'color_0', 'gray', Message, [], Instruction, PoseOut)</l>
+            <c/>
+            <c>* The number of files.</c>
+            <l>NumCalibrationScenes := 11</l>
+            <c/>
+            <c>* Creating the calibration model for the hand eye calibration</c>
+            <c>* using a moving 3D camera</c>
+            <l>create_calib_data ('hand_eye_moving_cam', 0, 0, HandEyeCalibrationDataID)</l>
+            <c/>
+            <c>* Setting the optimization method to be used</c>
+            <l>set_calib_data (HandEyeCalibrationDataID, 'model', 'general', 'optimization_method', 'nonlinear')</l>
+            <c/>
+            <c>* Determinining the 3D poses of the observed model object</c>
+            <c>* in all scenes using surface-based matching.</c>
+            <l>list_files (PointCloudDir, 'files', Files)</l>
+            <l>for I := 0 to |Files| - 1 by 1</l>
+            <c/>
+            <l>    read_object_model_3d (PointCloudDir + 'calibration_object_pose_' + I$'02d' + '.ply', 'mm', 'xyz_map_width', ImageWidth, OM3DScene, StatusReadPointCloud)</l>
+            <c/>
+            <c>    * Reading pose of flange (end-effector) in robot base coordinates (RobotPose)</c>
+            <l>    read_pose (RobotPosesDir + 'robot_pose_' + I$'02d' + '.dat', RobotPose)</l>
+            <c/>
+            <c>    * Getting color data to generate 2D RGB image</c>
+            <l>    get_object_model_3d_params (OM3DScene, 'red', red)</l>
+            <l>    get_object_model_3d_params (OM3DScene, 'green', green)</l>
+            <l>    get_object_model_3d_params (OM3DScene, 'blue', blue)</l>
+            <l>    set_object_model_3d_attrib (OM3DScene, '&amp;red', 'points', red, OM3DScene)</l>
+            <l>    set_object_model_3d_attrib (OM3DScene, '&amp;green', 'points', green, OM3DScene)</l>
+            <l>    set_object_model_3d_attrib (OM3DScene, '&amp;blue', 'points', blue, OM3DScene)</l>
+            <c/>
+            <c>    * Generating X, Y, and Z image</c>
+            <l>    object_model_3d_to_xyz (X, Y, Z, OM3DScene, 'from_xyz_map', [], [])</l>
+            <c/>
+            <c>    * Generating R, G, B, and RGB image</c>
+            <l>    generate_R_G_B_and_RGB_images (X, R, G, B, RGB, red, green, blue)</l>
+            <l>    rgb1_to_gray (RGB, GrayImage)</l>
+            <l>    get_image_size (GrayImage, Width, Height)</l>
+            <c/>
+            <c>    * Finding the surface model in the current scene</c>
+            <l>    find_surface_model (CalibrationObjectSurfaceModelID, OM3DScene, 0.05, 1, 0, 'true', [], [], ObjectToCameraPose, Score, SurfaceMatchingResultID)</l>
+            <l>    refine_surface_model_pose (CalibrationObjectSurfaceModelID, OM3DScene, ObjectToCameraPose, 0, 'false', [], [], ObjectToCameraPose, Score, SurfaceMatchingResultID1)</l>
+            <c/>
+            <c>    * Use this function if the surface matching is not working as intended</c>
+            <l>    * debug_find_surface_model (CalibrationObjectSurfaceModelID, SampledObjectModel3D, OM3DScene, SurfaceMatchingResultID, CreateSurfaceModelParamName, CreateSurfaceModelParamValue, FindSurfaceModelParamName, FindSurfaceModelParamValue)</l>
+            <c>    </c>
+            <l>    if (|Score|)</l>
+            <c>        * Only use the pose if the result of the surface-based matching is</c>
+            <c>        * good enough.</c>
+            <l>        set_calib_data (HandEyeCalibrationDataID, 'tool', I, 'tool_in_base_pose', RobotPose)</l>
+            <l>        set_calib_data_observ_pose (HandEyeCalibrationDataID, 0, 0, I, ObjectToCameraPose)</l>
+            <l>    endif</l>
+            <c/>
+            <c>    * To visualize in what pose the model was found in the scene,</c>
+            <c>    * transforming the 3D object model so that it can be overlaid onto</c>
+            <c>    * the current scene.</c>
+            <l>    pose_to_hom_mat3d (ObjectToCameraPose, HomMat3D)</l>
+            <l>    affine_trans_object_model_3d (SampledObjectModel3D, HomMat3D, OM3DModelTrans)</l>
+            <c/>
+            <c>    * Showing only interactive 3D visualization for the first three scenes</c>
+            <l>    if (I &lt; 4)</l>
+            <c>        * Clearing both windows</c>
+            <l>        dev_clear_window ()</l>
+            <l>        dev_set_window (ImageWindowHandle)</l>
+            <l>        dev_display (GrayImage)</l>
+            <l>        disp_message (ImageWindowHandle, 'Image from camera', 'window', 12, 12, 'black', 'true')</l>
+            <l>        dev_set_window (WindowHandle)</l>
+            <l>        Message := 'Surface model is matched in the 3D scene.'</l>
+            <l>        Message[1] := 'Points of the current scene are gray.'</l>
+            <l>        Message[2] := 'Points of the matched model are green.'</l>
+            <c/>
+            <c>        * Reducing the point density of the model for better visualization</c>
+            <l>        sample_object_model_3d (OM3DScene, 'fast', 0.0009, [], [], SampledOM3DScene)</l>
+            <l>        disp_message (WindowHandle, Message, 'window', 12, 12, 'black', 'true')</l>
+            <l>        Message := 'Scene: '</l>
+            <l>        Message[1] := I + ' of ' + NumCalibrationScenes</l>
+            <l>        disp_message (WindowHandle, Message, 'window', 80, 12, 'white', 'false')</l>
+            <c/>
+            <c>        * Visualizing matching result with user interaction</c>
+            <l>        visualize_object_model_3d (WindowHandle, [SampledOM3DScene,OM3DModelTrans], [], [], ['color_0', 'color_1', 'disp_background'], ['gray', 'green', 'true'], [], [], Instruction, PoseOut)</l>
+            <l>    else</l>
+            <c>        * Clearing both windows</c>
+            <l>        dev_clear_window ()</l>
+            <l>        dev_set_window (ImageWindowHandle)</l>
+            <l>        dev_clear_window ()</l>
+            <l>        dev_set_window (WindowHandle)</l>
+            <c>        </c>
+            <l>        if (I == 4)</l>
+            <l>            Message := 'In the following, the surface-based matching'</l>
+            <l>            Message[1] := 'result is shown using the 3D visualization '</l>
+            <l>            Message[2] := 'without user interaction.'</l>
+            <l>            disp_message (WindowHandle, Message, 'window', 12, 12, 'black', 'true')</l>
+            <l>            disp_continue_message (WindowHandle, 'black', 'true')</l>
+            <l>            stop ()</l>
+            <l>            dev_clear_window ()</l>
+            <l>        endif</l>
+            <l>        dev_set_window (ImageWindowHandle)</l>
+            <l>        dev_display (GrayImage)</l>
+            <l>        disp_message (ImageWindowHandle, 'Image from camera', 'window', 12, 12, 'black', 'true')</l>
+            <l>        dev_set_window (WindowHandle)</l>
+            <c/>
+            <c>        * Reducing the point density of the model for better visualization</c>
+            <l>        sample_object_model_3d (OM3DScene, 'fast', 0.0009, [], [], SampledOM3DScene)</l>
+            <c/>
+            <c>        * Visualizing matching result without user interaction</c>
+            <l>        disp_object_model_3d_safe (WindowHandle, [SampledOM3DScene,OM3DModelTrans], [], [], ['color_0', 'color_1'], ['gray', 'green'])</l>
+            <l>        Message := 'Scene: ' + I + ' of ' + NumCalibrationScenes</l>
+            <l>        disp_message (WindowHandle, Message, 'window', 12, 12, 'white', 'false')</l>
+            <l>    endif</l>
+            <l>endfor</l>
+            <c/>
+            <c>* Checking the input poses for consistency</c>
+            <l>check_hand_eye_calibration_input_poses (HandEyeCalibrationDataID, 0.05, 0.005, Warnings)</l>
+            <l>if (|Warnings| != 0)</l>
+            <c>    * There were problem detected in the input poses. Inspect Warnings and</c>
+            <c>    * remove erroneous poses with remove_calib_data and remove_calib_data_observ.</c>
+            <l>    dev_inspect_ctrl (Warnings)</l>
+            <l>    stop ()</l>
+            <l>endif</l>
+            <c/>
+            <c>* Now that all data has been collected,</c>
+            <c>* the hand-eye calibration can be performed.</c>
+            <l>dev_clear_window ()</l>
+            <l>disp_message (WindowHandle, 'Performing the hand-eye calibration', 'window', 12, 12, 'black', 'true')</l>
+            <l>calibrate_hand_eye (HandEyeCalibrationDataID, HECPoseError)</l>
+            <c/>
+            <l>get_calib_data(HandEyeCalibrationDataID, 'camera', 0, 'tool_in_cam_pose', DataValue)</l>
+            <l>pose_to_hom_mat3d(DataValue, HomMat3D)</l>
+            <l>hom_mat3d_invert (HomMat3D, HomMat3DInvert)</l>
+            <c/>
+            <c>* Getting poses computed by the hand eye calibration</c>
+            <l>get_calib_data (HandEyeCalibrationDataID, 'camera', 0, 'tool_in_cam_pose', CameraToEndEffectorPose)</l>
+            <l>get_calib_data (HandEyeCalibrationDataID, 'calib_obj', 0, 'obj_in_base_pose', BaseToCalibrationObjectPose)</l>
+            <c/>
+            <c>* Getting the plane in base coordinate system pose by translating the</c>
+            <c>* BaseToCalibrationObjectPose by the calibration object's thickness in the</c>
+            <c>* z-direction</c>
+            <l>set_origin_pose (BaseToCalibrationObjectPose, 0, 0, 0.005, PlaneInBasePose)</l>
+            <c/>
+            <l>try</l>
+            <c>    * Handling situation where user does not have the permission</c>
+            <c>    * to write in the current directory.</c>
+            <c>    * </c>
+            <c>    * Save the hand eye calibration results to file</c>
+            <l>    write_pose (CameraToEndEffectorPose, RobotPosesDir + 'final_pose_cam_tool.dat')</l>
+            <l>    write_pose (BaseToCalibrationObjectPose, RobotPosesDir + 'final_pose_base_calplate.dat')</l>
+            <l>    write_pose (PlaneInBasePose, RobotPosesDir + 'final_pose_base_plane.dat')</l>
+            <l>catch (Exception)</l>
+            <c>    * do nothing</c>
+            <l>endtry</l>
+            <c/>
+            <l>dev_display (GrayImage)</l>
+            <c/>
+            <c>* Displaying calibration errors</c>
+            <l>disp_results (WindowHandle, [], HECPoseError)</l>
+            <l>disp_continue_message (WindowHandle, 'black', 'true')</l>
+            <l>stop ()</l>
+            <c/>
+            <c>* For the given camera, get the corresponding pose indices and calibration object indices</c>
+            <l>query_calib_data_observ_indices (HandEyeCalibrationDataID, 'camera', 0, CalibObjIdx, PoseIds)</l>
+            <c/>
+            <c>* Computing the pose of the calibration object in the camera coordinate</c>
+            <c>* system via calibrated poses and the BaseToEndEffectorPose and visualize it.</c>
+            <c>* Set sizes for 3D visualization in [m]</c>
+            <l>CameraSize := 0.05</l>
+            <l>CameraConeLength := 0.3</l>
+            <l>rigid_trans_object_model_3d (SampledObjectModel3D, BaseToCalibrationObjectPose, OM3DObject)</l>
+            <l>dev_open_window (0, Width + 10, Width/4, Height/4, 'black', WindowHandleR)</l>
+            <l>set_display_font (WindowHandleR, 14, 'mono', 'true', 'false')</l>
+            <l>ParamName := ['color_0', 'color_1', 'color_2', 'color_3', 'color_4', 'color_5', 'color_6', 'color_7', 'alpha_7', 'color_8', 'color_9', 'color_10', 'alpha_8', 'alpha_9', 'alpha_10', 'point_size']</l>
+            <l>ParamValue := ['red', 'red', 'green', 'blue', 'red', 'green', 'blue', 'white', 0.7, 'magenta', 'yellow', 'white', 0.5, 0.5, 0.5, 5]</l>
+            <c/>
+            <c>* Labels for the visualized 3D object models</c>
+            <l>tuple_gen_const (11, '', Labels)</l>
+            <l>Labels[0] := 'Calibration Object'</l>
+            <l>Labels[1] := 'Robot\'s Flange (end-effector)'</l>
+            <l>Labels[4] := 'Robot\'s Base'</l>
+            <l>Labels[8] := 'Camera'</l>
+            <l>Instructions[0] := 'Rotate: Left button'</l>
+            <l>Instructions[1] := 'Zoom:   Shift + left button'</l>
+            <l>Instructions[2] := 'Move:   Ctrl  + left button'</l>
+            <c/>
+            <c>* Set size for 3D visualization in [m]</c>
+            <l>ArrowThickness := 0.005</l>
+            <l>ArrowLength := 0.05</l>
+            <l>gen_robot_tool_and_base_object_model_3d (ArrowThickness, ArrowLength, OM3DToolOrigin, OM3DBase)</l>
+            <c/>
+            <l>for I := 0 to |Files| - 1 by 1</l>
+            <l>    dev_set_window (WindowHandle)</l>
+            <l>    dev_clear_window ()</l>
+            <c/>
+            <c>    * Reading a 3D object model from PLY file</c>
+            <l>    read_object_model_3d (PointCloudDir + 'calibration_object_pose_' + I$'02d' + '.ply', 'mm', 'xyz_map_width', ImageWidth, OM3DScene, StatusReadPointCloud)</l>
+            <c/>
+            <c>    * Getting color data to generate 2D RGB image</c>
+            <l>    get_object_model_3d_params (OM3DScene, 'red', red)</l>
+            <l>    get_object_model_3d_params (OM3DScene, 'green', green)</l>
+            <l>    get_object_model_3d_params (OM3DScene, 'blue', blue)</l>
+            <l>    set_object_model_3d_attrib (OM3DScene, '&amp;red', 'points', red, ObjectModel3D)</l>
+            <l>    set_object_model_3d_attrib (OM3DScene, '&amp;green', 'points', green, ObjectModel3D)</l>
+            <l>    set_object_model_3d_attrib (OM3DScene, '&amp;blue', 'points', blue, ObjectModel3D)</l>
+            <c/>
+            <c>    * Generating X, Y, and Z image</c>
+            <l>    object_model_3d_to_xyz (X, Y, Z, OM3DScene, 'from_xyz_map', [], [])</l>
+            <c/>
+            <c>    * Generating R, G, B, and RGB image</c>
+            <l>    generate_R_G_B_and_RGB_images (X, R, G, B, RGB, red, green, blue)</l>
+            <l>    rgb1_to_gray (RGB, GrayImage)</l>
+            <l>    convert_image_type (GrayImage, GrayImage, 'byte')</l>
+            <l>    dev_display (GrayImage)</l>
+            <c/>
+            <c>    * Obtaining the pose of the flange (end-effector) in robot base coordinates used in the calibration.</c>
+            <c>    * The index corresponds to the index of the pose of the observation object.</c>
+            <l>    get_calib_data (HandEyeCalibrationDataID, 'tool', PoseIds[I], 'tool_in_base_pose', BaseToEndEffectorPose)</l>
+            <c/>
+            <c>    * Computing the pose of the calibration object relative to the camera</c>
+            <l>    calc_calplate_pose_eye_in_hand (BaseToCalibrationObjectPose, CameraToEndEffectorPose, BaseToEndEffectorPose, CameraToCalibrationObjectPose)</l>
+            <c/>
+            <c>    * Displaying the coordinate system</c>
+            <l>    dev_set_colored (3)</l>
+            <l>    gen_cam_par_area_scan_division (0.008, 0, 5.2e-06, 5.2e-06, 640, 512, 1280, 1024, ArtificalCameraParams)</l>
+            <l>    gen_camera_and_tool_moving_cam_object_model_3d (CameraToEndEffectorPose, BaseToEndEffectorPose, CameraSize, CameraConeLength, OM3DToolOrigin, \
+                                                    ArtificalCameraParams, OM3DCamera, OM3DTool)</l>
+            <l>    Message := 'Using the calibration results to display '</l>
+            <l>    Message[1] := 'the coordinate system in image ' + (I + 1) + ' of ' + |Files|</l>
+            <l>    disp_message (WindowHandle, Message, 'window', 12, 12, 'black', 'true')</l>
+            <l>    if (I == 0)</l>
+            <l>        VisualizationPoseIn := [-0.122133, 0.460322, 18.1503, 106.933, 359.48, 257.771, 0]</l>
+            <l>    else</l>
+            <l>        VisualizationPoseIn := VisualizationPoseOut</l>
+            <l>    endif</l>
+            <l>    visualize_object_model_3d (WindowHandleR, [OM3DObject,OM3DTool,OM3DBase,OM3DCamera], [], VisualizationPoseIn, ParamName, ParamValue, [], Labels, Instructions, VisualizationPoseOut)</l>
+            <l>endfor</l>
+            <c/>
+            <c>* Clearing the data model</c>
+            <l>clear_calib_data (HandEyeCalibrationDataID)</l>
+            <l>dev_set_window (WindowHandleR)</l>
+            <l>dev_close_window ()</l>
+            <c/>
+            <c>* </c>
+            <c>* After the hand-eye calibration the computed pose</c>
+            <c>* CameraToEndEffectorPose can be used in robotic grasping applications.</c>
+            <c>* To grasp an object with the robot, typically, its pose</c>
+            <c>* with respect to the camera is determined (which</c>
+            <c>* is simulated here by setting the object's pose to the</c>
+            <c>* pose of the calibration object)</c>
+            <l>ObjectToCameraPose := CameraToCalibrationObjectPose</l>
+            <c/>
+            <c>* If the flange (end-effector) coordinate system is placed at the gripper</c>
+            <c>* and a detected object ObjectToCameraPose shall be grasped</c>
+            <c>* (here the calibration object),</c>
+            <c>* the pose of the detected object relative</c>
+            <c>* to the robot base coordinate system has to be computed.</c>
+            <l>pose_invert (CameraToEndEffectorPose, EndEffectorToCameraPose)</l>
+            <l>pose_compose (BaseToEndEffectorPose, EndEffectorToCameraPose, BaseToCameraPose)</l>
+            <l>pose_compose (BaseToCameraPose, ObjectToCameraPose, BaseToObjectPose)</l>
+        </body>
+        <docu id="main">
+            <parameters/>
+        </docu>
+    </procedure>
+    <procedure name="disp_results">
+        <interface>
+            <ic>
+                <par name="WindowHandle" base_type="ctrl" dimension="0"/>
+                <par name="CamCalibError" base_type="ctrl" dimension="0"/>
+                <par name="Errors" base_type="ctrl" dimension="0"/>
+            </ic>
+        </interface>
+        <body>
+            <l>dev_clear_window ()</l>
+            <l>Message := 'Quality of the results:'</l>
+            <l>disp_message (WindowHandle, Message, 'window', 12, 12, 'black', 'true')</l>
+            <l>Message := 'Error of the camera calibration:      ' + CamCalibError$'6.4f' + ' pixel'</l>
+            <l>disp_message (WindowHandle, Message, 'window', 52, 12, 'black', 'true')</l>
+            <l>Message := 'Errors of the hand eye calibration:'</l>
+            <l>disp_message (WindowHandle, Message, 'window', 92, 12, 'black', 'true')</l>
+            <l>DispErrors := []</l>
+            <l>DispErrors := [DispErrors,'                     |   RMS    |  Maximum |']</l>
+            <l>DispErrors := [DispErrors,'|--------------------+----------+----------|']</l>
+            <l>DispErrors := [DispErrors,'| Translational part | ' + (Errors[0] * 1e3)$'5.3f' + ' mm | ' + (Errors[2] * 1e3)$'5.3f' + ' mm |']</l>
+            <l>DispErrors := [DispErrors,'| Rotational part    | ' + Errors[1]$'5.3f' + ' °  | ' + Errors[3]$'5.3f' + ' °  |']</l>
+            <l>disp_message (WindowHandle, DispErrors, 'window', 132, 40, 'black', 'true')</l>
+            <l>return ()</l>
+        </body>
+        <docu id="disp_results">
+            <parameters>
+                <parameter id="CamCalibError"/>
+                <parameter id="Errors"/>
+                <parameter id="WindowHandle"/>
+            </parameters>
+        </docu>
+    </procedure>
+</hdevelop>

--- a/source/Applications/Advanced/HandEyeCalibration/EyeInHandCalibrationMVTecPlate.hdev
+++ b/source/Applications/Advanced/HandEyeCalibration/EyeInHandCalibrationMVTecPlate.hdev
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hdevelop file_version="1.2" halcon_version="25.11.0.0">
+    <procedure name="main">
+        <interface/>
+        <body>
+            <c>*</c>
+            <c>* Hand-eye calibration with a Zivid camera and MVTec calibration plate</c>
+            <c>*</c>
+            <c>* This example explains how to use the hand eye calibration for the case where</c>
+            <c>* the camera is attached to the robot flange (end-effector) and the calibration object</c>
+            <c>* is stationary with respect to the robot (Eye-In-Hand). The robot positions the</c>
+            <c>* camera with respect to the calibration plate.</c>
+            <c>* In this case, the goal of the hand eye calibration is to determine two unknown poses:</c>
+            <c>* - the pose of the robot base in the coordinate system</c>
+            <c>*   of the calibration object (BaseToCalibrationObjectPose).</c>
+            <c>* - the pose of the camera in the coordinate system of the</c>
+            <c>*   tool center point (CameraToEndEffectorPose).</c>
+            <c>* Theoretically, as input the method needs at least 3 poses of the</c>
+            <c>* calibration object in the camera coordinate system.</c>
+            <c>* However, it is recommended to use at least 10 Poses.</c>
+            <c>* The corresponding poses of the robot flange (end-effector) in the robot base coordinate system</c>
+            <c>* (BaseToEndEffectorPose) changes for each calibration image,</c>
+            <c>* because it describes the pose of the robot moving the camera.</c>
+            <c>* The poses of the calibration object are obtained from images of the</c>
+            <c>* calibration object captured with the camera attached to the robot.</c>
+            <c>* To obtain good calibration results, it its essential to position</c>
+            <c>* the camera with respect to the calibration object so that the object appears</c>
+            <c>* tilted in the image.</c>
+            <c>* After the hand eye calibration, the computed transformations are</c>
+            <c>* extracted and used to compute the pose of the calibration object in the</c>
+            <c>* camera coordinate system.</c>
+            <c>*</c>
+            <c/>
+            <l>import './../../../Procedures'</l>
+            <c/>
+            <l>dev_update_off ()</l>
+            <c>* Reading the initial values for the Zivid camera intrinsics </c>
+            <c>* Use either hard-coded camera intrinsics or intrinsics estimated from the point cloud (recommended)</c>
+            <c>* https://support.zivid.com/en/latest/reference-articles/camera-intrinsics.html</c>
+            <l>get_zivid_sample_data_dir(ZividDataDir)</l>
+            <l>read_cam_par(ZividDataDir + '/ZividHandEyeHalconData/estimated_intrinsics.dat', InputCameraParameters)</l>
+            <c/>
+            <c>* Setting path and reading a 3D object model from PLY file</c>
+            <l>PointCloudDir := ZividDataDir + '/ZividHandEyeHalconData/CalibrationPlatePointClouds/'</l>
+            <l>RobotPosesDir := ZividDataDir + '/ZividHandEyeHalconData/RobotPoses/'</l>
+            <l>ImageWidth := InputCameraParameters[11]</l>
+            <l>read_object_model_3d (PointCloudDir + 'calibration_object_pose_00.ply', 'mm', 'xyz_map_width', ImageWidth, ObjectModel3D, Status)</l>
+            <c/>
+            <c>* Getting color data to generate 2D RGB image</c>
+            <l>get_object_model_3d_params (ObjectModel3D, 'red', red)</l>
+            <l>get_object_model_3d_params (ObjectModel3D, 'green', green)</l>
+            <l>get_object_model_3d_params (ObjectModel3D, 'blue', blue)</l>
+            <l>set_object_model_3d_attrib (ObjectModel3D, '&amp;red', 'points', red, ObjectModel3D)</l>
+            <l>set_object_model_3d_attrib (ObjectModel3D, '&amp;green', 'points', green, ObjectModel3D)</l>
+            <l>set_object_model_3d_attrib (ObjectModel3D, '&amp;blue', 'points', blue, ObjectModel3D)</l>
+            <c/>
+            <c>* Generating X, Y, and Z image</c>
+            <l>object_model_3d_to_xyz (X, Y, Z, ObjectModel3D, 'from_xyz_map', [], [])</l>
+            <c/>
+            <c>* Generating R, G, B, and RGB image</c>
+            <l>generate_R_G_B_and_RGB_images (X, R, G, B, RGB, red, green, blue)</l>
+            <l>rgb1_to_gray (RGB, GrayImage)</l>
+            <c/>
+            <c>* Displaying first image of the dataset</c>
+            <l>dev_close_window ()</l>
+            <l>get_image_size (GrayImage, Width, Height)</l>
+            <l>dev_open_window (0, 0, Width/4, Height/4, 'black', WindowHandle)</l>
+            <l>dev_set_line_width (2)</l>
+            <l>dev_set_draw ('margin')</l>
+            <l>dev_display (GrayImage)</l>
+            <l>set_display_font (WindowHandle, 14, 'mono', 'true', 'false')</l>
+            <c/>
+            <c>* Loading the calibration plate description file.</c>
+            <c>* Make sure that the file is in the sample data directory.</c>
+            <c>* https://support.zivid.com/en/latest/api-reference/samples/sample-data.html</c>
+            <l>CalibrationPlateFile := ZividDataDir + '/ZividHandEyeHalconData/320_20978-A-00423.cpd'</l>
+            <c/>
+            <c>* Creating the calibration model for the hand eye calibration</c>
+            <c>* where the calibration object is observed with a camera</c>
+            <l>create_calib_data ('hand_eye_moving_cam', 1, 1, CalibDataID)</l>
+            <l>set_calib_data_cam_param (CalibDataID, 0, [], InputCameraParameters)</l>
+            <l>set_calib_data_calib_object (CalibDataID, 0, CalibrationPlateFile)</l>
+            <c/>
+            <c>* Exclude camera calibration from hand-eye calibration process</c>
+            <c>* If you want to use the Zivid camera intrinsics parameters,</c>
+            <c>* you need to uncomment the line below</c>
+            <l>* set_calib_data(CalibDataID,'camera','general','excluded_settings','params')</l>
+            <c/>
+            <c>* Setting the optimization method to be used</c>
+            <l>set_calib_data (CalibDataID, 'model', 'general', 'optimization_method', 'nonlinear')</l>
+            <c/>
+            <l>disp_message (WindowHandle, 'The calibration data model was created', 'window', 12, 12, 'black', 'true')</l>
+            <l>disp_continue_message (WindowHandle, 'black', 'true')</l>
+            <l>stop ()</l>
+            <c/>
+            <c>* Preparing the second window for robot pose visualization</c>
+            <l>ParamName := ['color_0', 'color_1', 'color_2', 'color_3', 'color_4', 'color_5', 'color_6', 'alpha_6']</l>
+            <l>ParamValue := ['red', 'green', 'blue', 'red', 'green', 'blue', 'white', 0.7]</l>
+            <c>* Labels for the visualized 3D object models.</c>
+            <l>tuple_gen_const (7, '', Labels)</l>
+            <l>Labels[0] := 'Robot\'s Flange (end-effector)'</l>
+            <l>Labels[3] := 'Robot\'s Base'</l>
+            <l>Instructions[0] := 'Rotate: Left button'</l>
+            <l>Instructions[1] := 'Zoom:   Shift + left button'</l>
+            <l>Instructions[2] := 'Move:   Ctrl  + left button'</l>
+            <c>* Set size for 3D visualization in [m]</c>
+            <l>ArrowThickness := 0.005</l>
+            <l>ArrowLength := 0.05</l>
+            <l>gen_robot_tool_and_base_object_model_3d (ArrowThickness, ArrowLength, OM3DEndEffectorOrigin, OM3DBase)</l>
+            <l>dev_open_window (0, Width/4 + 10, Width/4, Height/4, 'black', WindowHandleR)</l>
+            <l>set_display_font (WindowHandleR, 14, 'mono', 'true', 'false')</l>
+            <c/>
+            <l>list_files (PointCloudDir, 'files', Files)</l>
+            <l>for I := 0 to |Files| - 1 by 1</l>
+            <l>    dev_set_window (WindowHandle)</l>
+            <l>    dev_clear_window ()</l>
+            <c>    </c>
+            <c>    * Reading a 3D object model from PLY file</c>
+            <l>    read_object_model_3d (PointCloudDir + 'calibration_object_pose_' + I$'02d' + '.ply', 'mm', 'xyz_map_width', ImageWidth, ObjectModel3D, Status)</l>
+            <c>    </c>
+            <c>    * Getting color data to generate 2D RGB image</c>
+            <l>    get_object_model_3d_params (ObjectModel3D, 'red', red)</l>
+            <l>    get_object_model_3d_params (ObjectModel3D, 'green', green)</l>
+            <l>    get_object_model_3d_params (ObjectModel3D, 'blue', blue)</l>
+            <l>    set_object_model_3d_attrib (ObjectModel3D, '&amp;red', 'points', red, ObjectModel3D)</l>
+            <l>    set_object_model_3d_attrib (ObjectModel3D, '&amp;green', 'points', green, ObjectModel3D)</l>
+            <l>    set_object_model_3d_attrib (ObjectModel3D, '&amp;blue', 'points', blue, ObjectModel3D)</l>
+            <c>    </c>
+            <c>    * Generating X, Y, and Z image</c>
+            <l>    object_model_3d_to_xyz (X, Y, Z, ObjectModel3D, 'from_xyz_map', [], [])</l>
+            <c>    </c>
+            <c>    * Generating R, G, B, and RGB image</c>
+            <l>    generate_R_G_B_and_RGB_images (X, R, G, B, RGB, red, green, blue)</l>
+            <l>    rgb1_to_gray (RGB, GrayImage)</l>
+            <l>    convert_image_type (GrayImage, GrayImage, 'byte')</l>
+            <c>    </c>
+            <c>    * Searching for the calibration plate, extracting the marks and the</c>
+            <c>    * pose of it, and storing the results in the calibration data</c>
+            <c>    * The poses are stored in the calibration data model for use by</c>
+            <c>    * the hand eye calibration and do not have to be set explicitly</c>
+            <l>    try</l>
+            <l>        find_calib_object (GrayImage, CalibDataID, 0, 0, I, ['sigma'], [2])</l>
+            <l>        get_calib_data_observ_contours (Caltab, CalibDataID, 'caltab', 0, 0, I)</l>
+            <l>        get_calib_data_observ_points (CalibDataID, 0, 0, I, RCoord, CCoord, Index, PoseForCalibrationPlate)</l>
+            <c>        </c>
+            <c>        * Visualizing the extracted calibration marks and the estimated pose (coordinate system)</c>
+            <l>        dev_set_color ('green')</l>
+            <l>        dev_display (GrayImage)</l>
+            <l>        dev_display (Caltab)</l>
+            <l>        dev_set_color ('yellow')</l>
+            <l>        disp_cross (WindowHandle, RCoord, CCoord, 6, 0)</l>
+            <l>        dev_set_colored (3)</l>
+            <l>        disp_3d_coord_system (WindowHandle, InputCameraParameters, PoseForCalibrationPlate, 0.01)</l>
+            <l>        disp_message (WindowHandle, 'Extracting data from calibration image ' + (I + 1) + ' of ' + |Files|, 'window', 12, 12, 'black', 'true')</l>
+            <c>        </c>
+            <c>        * Reading pose of tool in robot base coordinates (RobotPose)</c>
+            <l>        read_pose (RobotPosesDir + 'robot_pose_' + I$'02d' + '.dat', RobotPose)</l>
+            <c>        </c>
+            <c>        * Visualzation of coordinate systems</c>
+            <l>        if (I == 0)</l>
+            <l>            VisualizationPoseIn := [-0.122133, 0.460322, 18.1503, 106.933, 359.48, 257.771, 0]</l>
+            <l>        else</l>
+            <l>            VisualizationPoseIn := VisualizationPoseOut</l>
+            <l>        endif</l>
+            <l>        rigid_trans_object_model_3d (OM3DEndEffectorOrigin, RobotPose, OM3DEndEffector)</l>
+            <l>        visualize_object_model_3d (WindowHandleR, [OM3DEndEffector,OM3DBase], [], VisualizationPoseIn, ParamName, ParamValue, 'Flange (end-effector) pose in robot base frame', Labels, Instructions, VisualizationPoseOut)</l>
+            <c/>
+            <c>        * Setting the flange (end-effector) pose in robot base frame in the calibration data model</c>
+            <l>        set_calib_data (CalibDataID, 'tool', I, 'tool_in_base_pose', RobotPose)</l>
+            <l>    catch (Exception)</l>
+            <l>*         stop()</l>
+            <l>    endtry</l>
+            <c>    </c>
+            <l>endfor</l>
+            <c/>
+            <l>dev_set_window (WindowHandleR)</l>
+            <l>dev_close_window ()</l>
+            <l>disp_message (WindowHandle, 'All relevant data has been set in the calibration data model', 'window', 12, 12, 'black', 'true')</l>
+            <l>disp_continue_message (WindowHandle, 'black', 'true')</l>
+            <l>stop ()</l>
+            <c/>
+            <c>* Checking the input poses for consistency</c>
+            <l>check_hand_eye_calibration_input_poses (CalibDataID, 0.05, 0.005, Warnings)</l>
+            <l>if (|Warnings| != 0)</l>
+            <c>    * There were problem detected in the input poses. Inspect Warnings and</c>
+            <c>    * remove erroneous poses with remove_calib_data and remove_calib_data_observ.</c>
+            <l>    dev_inspect_ctrl (Warnings)</l>
+            <l>    stop ()</l>
+            <l>endif</l>
+            <c/>
+            <c>* </c>
+            <c>* Perform the hand eye calibration and store the results to file</c>
+            <c>* The calibration of the cameras is done internally prior</c>
+            <c>* to the hand eye calibration</c>
+            <l>dev_display (GrayImage)</l>
+            <c/>
+            <l>disp_message (WindowHandle, 'Performing the hand-eye calibration', 'window', 12, 12, 'black', 'true')</l>
+            <l>calibrate_hand_eye (CalibDataID, Errors)</l>
+            <c/>
+            <c>* Querying the error of the camera calibration</c>
+            <l>get_calib_data (CalibDataID, 'model', 'general', 'camera_calib_error', CamCalibError)</l>
+            <c/>
+            <c>* Querying the camera parameters and the poses</c>
+            <l>get_calib_data (CalibDataID, 'camera', 0, 'params', OutputCameraParameters)</l>
+            <c/>
+            <c>* Getting poses computed by the hand eye calibration</c>
+            <l>get_calib_data (CalibDataID, 'camera', 0, 'tool_in_cam_pose', CameraToEndEffectorPose)</l>
+            <l>get_calib_data (CalibDataID, 'calib_obj', 0, 'obj_in_base_pose', BaseToCalibrationObjectPose)</l>
+            <c/>
+            <c>* Getting homogenous transformation matrix</c>
+            <l>pose_invert(CameraToEndEffectorPose, EndEffectorToCameraPose)</l>
+            <l>pose_to_hom_mat3d (EndEffectorToCameraPose, EndEffectorToCameraMatrix)</l>
+            <c/>
+            <c>* Getting the plane in base coordinate system pose by translating the</c>
+            <c>* BaseToCalibrationObjectPose by the calibration object's thickness in the</c>
+            <c>* z-direction.</c>
+            <l>set_origin_pose (BaseToCalibrationObjectPose, 0, 0, 0.005, BaseToCalibrationObjectBottomPlanePose)</l>
+            <c/>
+            <l>try</l>
+            <c>    * Handling situation where user does not have the permission</c>
+            <c>    * to write in the current directory.</c>
+            <c>    * </c>
+            <c>    * Storing the camera parameters to file</c>
+            <l>    write_cam_par (OutputCameraParameters, RobotPosesDir + 'output_camera_parameters.dat')</l>
+            <c/>
+            <c>    * Saving the hand eye calibration results to file</c>
+            <l>    write_pose (CameraToEndEffectorPose, RobotPosesDir + 'camera_to_end_effector_pose.dat')</l>
+            <l>    write_pose (EndEffectorToCameraPose, RobotPosesDir + 'end_effector_to_camera_pose.dat')</l>
+            <l>    write_pose (BaseToCalibrationObjectPose, RobotPosesDir + 'base_to_calibration_object_pose.dat')</l>
+            <l>    write_pose (BaseToCalibrationObjectBottomPlanePose, RobotPosesDir + 'base_to_calibration_object_bottom_plane_pose.dat')    </l>
+            <l>catch (Exception)</l>
+            <c/>
+            <l>endtry</l>
+            <c/>
+            <c>* Displaying calibration errors</c>
+            <l>dev_display (GrayImage)</l>
+            <l>disp_results (WindowHandle, CamCalibError, Errors)</l>
+            <l>disp_continue_message (WindowHandle, 'black', 'true')</l>
+            <l>stop ()</l>
+            <c/>
+            <c>* Computing the calibration object marker points in the base frame of the robot</c>
+            <l>get_calib_data (CalibDataID, 'calib_obj', 0, 'x', PX)</l>
+            <l>get_calib_data (CalibDataID, 'calib_obj', 0, 'y', PY)</l>
+            <l>get_calib_data (CalibDataID, 'calib_obj', 0, 'z', PZ)</l>
+            <l>gen_object_model_3d_from_points (PX, PY, PZ, OM3DCalibrationObject)</l>
+            <l>rigid_trans_object_model_3d (OM3DCalibrationObject, BaseToCalibrationObjectPose, OM3DCalibrationObjectInBaseFrame)</l>
+            <c/>
+            <c>* Setting sizes for 3D visualization in [m]</c>
+            <l>CameraSize := 0.05</l>
+            <l>CameraConeLength := 0.3</l>
+            <c/>
+            <l>dev_open_window (0, Width + 10, Width/4, Height/4, 'black', WindowHandleR)</l>
+            <l>set_display_font (WindowHandleR, 14, 'mono', 'true', 'false')</l>
+            <l>ParamName := ['color_0', 'color_1', 'color_2', 'color_3', 'color_4', 'color_5', 'color_6', 'color_7', 'alpha_7', 'color_8', 'color_9', 'color_10', 'alpha_8', 'alpha_9', 'alpha_10', 'point_size']</l>
+            <l>ParamValue := ['red', 'red', 'green', 'blue', 'red', 'green', 'blue', 'white', 0.7, 'magenta', 'yellow', 'white', 0.5, 0.5, 0.5, 5]</l>
+            <c/>
+            <c>* Labels for the visualized 3D object models.</c>
+            <l>tuple_gen_const (11, '', Labels)</l>
+            <l>Labels[0] := 'Calibration Plate'</l>
+            <l>Labels[1] := 'Robot\'s Flange (end-effector)'</l>
+            <l>Labels[4] := 'Robot\'s Base'</l>
+            <l>Labels[8] := 'Camera'</l>
+            <c/>
+            <l>for I := 0 to |Files| - 1 by 1</l>
+            <l>    dev_set_window (WindowHandle)</l>
+            <l>    dev_clear_window ()</l>
+            <c>    </c>
+            <c>    * Reading a 3D object model from PLY file.</c>
+            <l>    read_object_model_3d (PointCloudDir + 'calibration_object_pose_' + I$'02d' + '.ply', 'mm', 'xyz_map_width', ImageWidth, ObjectModel3D, Status)</l>
+            <c>    </c>
+            <c>    * Getting color data to generate 2D RGB image</c>
+            <l>    get_object_model_3d_params (ObjectModel3D, 'red', red)</l>
+            <l>    get_object_model_3d_params (ObjectModel3D, 'green', green)</l>
+            <l>    get_object_model_3d_params (ObjectModel3D, 'blue', blue)</l>
+            <l>    set_object_model_3d_attrib (ObjectModel3D, '&amp;red', 'points', red, ObjectModel3D)</l>
+            <l>    set_object_model_3d_attrib (ObjectModel3D, '&amp;green', 'points', green, ObjectModel3D)</l>
+            <l>    set_object_model_3d_attrib (ObjectModel3D, '&amp;blue', 'points', blue, ObjectModel3D)</l>
+            <c/>
+            <c>    * Generating X, Y, and Z image.</c>
+            <l>    object_model_3d_to_xyz (X, Y, Z, ObjectModel3D, 'from_xyz_map', [], [])</l>
+            <c>    </c>
+            <c>    * Generating R, G, B, and RGB image.</c>
+            <l>    generate_R_G_B_and_RGB_images (X, R, G, B, RGB, red, green, blue)</l>
+            <l>    rgb1_to_gray (RGB, GrayImage)</l>
+            <l>    convert_image_type (GrayImage, GrayImage, 'byte')</l>
+            <l>    dev_display (GrayImage)</l>
+            <c>    </c>
+            <c>    * Obtaining the pose of the flange (end-effector) in robot base coordinates used in the calibration.</c>
+            <l>    get_calib_data (CalibDataID, 'tool', I, 'tool_in_base_pose', BaseToEndEffectorPose)</l>
+            <c/>
+            <c>    * Computing the pose of the calibration object relative to the camera</c>
+            <l>    calc_calplate_pose_eye_in_hand (BaseToCalibrationObjectPose, CameraToEndEffectorPose, BaseToEndEffectorPose, CameraToCalibrationObjectPose)</l>
+            <c/>
+            <c>    * Displaying the coordinate system</c>
+            <l>    dev_set_colored (3)</l>
+            <l>    disp_3d_coord_system (WindowHandle, OutputCameraParameters, CameraToCalibrationObjectPose, 0.01)</l>
+            <l>    Message := 'Using the calibration results to display '</l>
+            <l>    Message[1] := 'the coordinate system in image ' + (I + 1) + ' of ' + |Files|</l>
+            <l>    disp_message (WindowHandle, Message, 'window', 12, 12, 'black', 'true')</l>
+            <l>    gen_camera_and_tool_moving_cam_object_model_3d (CameraToEndEffectorPose, BaseToEndEffectorPose, CameraSize, CameraConeLength, OM3DEndEffectorOrigin, OutputCameraParameters, OM3DCamera, OM3DEndEffector)</l>
+            <l>    if (I == 0)</l>
+            <l>        VisualizationPoseIn := [-0.122133, 0.460322, 18.1503, 106.933, 359.48, 257.771, 0]</l>
+            <l>    else</l>
+            <l>        VisualizationPoseIn := VisualizationPoseOut</l>
+            <l>    endif</l>
+            <l>    visualize_object_model_3d (WindowHandleR, [OM3DCalibrationObjectInBaseFrame,OM3DEndEffector,OM3DBase,OM3DCamera], [], VisualizationPoseIn, ParamName, ParamValue, [], Labels, Instructions, VisualizationPoseOut)</l>
+            <l>endfor</l>
+            <c/>
+            <c>* Clearing the data model</c>
+            <l>clear_calib_data (CalibDataID)</l>
+            <l>dev_set_window (WindowHandleR)</l>
+            <l>dev_close_window ()</l>
+            <c/>
+            <c>* </c>
+            <c>* After the hand-eye calibration the computed pose</c>
+            <c>* CameraToEndEffectorPose can be used in robotic grasping applications.</c>
+            <c>* To grasp an object with the robot, typically, its pose</c>
+            <c>* with respect to the camera is determined (which</c>
+            <c>* is simulated here by setting the object's pose to the</c>
+            <c>* pose of the calibration object)</c>
+            <l>CameraToObjectPose := CameraToCalibrationObjectPose</l>
+            <c/>
+            <c>* If the end-effector coordinate system is placed at the gripper</c>
+            <c>* and a detected object CameraToObjectPose shall be grasped</c>
+            <c>* (here the calibration object),</c>
+            <c>* the pose of the detected object relative</c>
+            <c>* to the robot base coordinate system has to be computed.</c>
+            <l>pose_invert (CameraToEndEffectorPose, EndEffectorToCameraPose)</l>
+            <l>pose_compose (BaseToEndEffectorPose, EndEffectorToCameraPose, BaseToCameraPose)</l>
+            <l>pose_compose (BaseToCameraPose, CameraToObjectPose, BaseToObjectPose)</l>
+            <c/>
+        </body>
+        <docu id="main">
+            <parameters/>
+        </docu>
+    </procedure>
+    <procedure name="disp_results">
+        <interface>
+            <ic>
+                <par name="WindowHandle" base_type="ctrl" dimension="0"/>
+                <par name="CamCalibError" base_type="ctrl" dimension="0"/>
+                <par name="Errors" base_type="ctrl" dimension="0"/>
+            </ic>
+        </interface>
+        <body>
+            <l>dev_clear_window ()</l>
+            <l>Message := 'Quality of the results:'</l>
+            <l>disp_message (WindowHandle, Message, 'window', 12, 12, 'black', 'true')</l>
+            <l>Message := 'Error of the camera calibration:      ' + CamCalibError$'6.4f' + ' pixel'</l>
+            <l>disp_message (WindowHandle, Message, 'window', 52, 12, 'black', 'true')</l>
+            <l>Message := 'Errors of the hand eye calibration:'</l>
+            <l>disp_message (WindowHandle, Message, 'window', 92, 12, 'black', 'true')</l>
+            <l>DispErrors := []</l>
+            <l>DispErrors := [DispErrors,'                     |   RMS    |  Maximum |']</l>
+            <l>DispErrors := [DispErrors,'|--------------------+----------+----------|']</l>
+            <l>DispErrors := [DispErrors,'| Translational part | ' + (Errors[0] * 1e3)$'5.3f' + ' mm | ' + (Errors[2] * 1e3)$'5.3f' + ' mm |']</l>
+            <l>DispErrors := [DispErrors,'| Rotational part    | ' + Errors[1]$'5.3f' + ' °  | ' + Errors[3]$'5.3f' + ' °  |']</l>
+            <l>disp_message (WindowHandle, DispErrors, 'window', 132, 40, 'black', 'true')</l>
+            <l>return ()</l>
+        </body>
+        <docu id="disp_results">
+            <parameters>
+                <parameter id="CamCalibError"/>
+                <parameter id="Errors"/>
+                <parameter id="WindowHandle"/>
+            </parameters>
+        </docu>
+    </procedure>
+</hdevelop>

--- a/source/Applications/Advanced/HandEyeCalibration/JSONHomogeneousMatrixToHalconPose.hdev
+++ b/source/Applications/Advanced/HandEyeCalibration/JSONHomogeneousMatrixToHalconPose.hdev
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hdevelop file_version="1.2" halcon_version="25.11.0.0">
+    <procedure name="main">
+        <interface/>
+        <body>
+            <c>*</c>
+            <c>* Transform homogenous matrixes to halcon pose</c>
+            <c>*</c>
+            <c>* Remember that translation part of the homogeneous matrix should be in meters</c>
+            <c>* It expects a matrix in this format:</c>
+            <c>* {</c>
+            <c>*  "Data": [</c>
+            <c>*    [-0.0268069, 0.9914033, -0.1280658, -0.3689413],</c>
+            <c>*    [0.99952, 0.02857302, 0.01197316, 0.2234139999],</c>
+            <c>*    [0.01552946, -0.1276834, -0.9916934, 0.8008651],</c>
+            <c>*    [0, 0, 0, 1]</c>
+            <c>*  ]</c>
+            <c>* }</c>
+            <c/>
+            <l>main_path := '.'</l>
+            <c/>
+            <c>* Checking if this folder exists</c>
+            <l>file_exists(main_path + '/robot_poses_halcon/', Exists)</l>
+            <l>if (not Exists)</l>
+            <l>    make_dir(main_path + '/robot_poses_halcon/')</l>
+            <l>endif</l>
+            <c/>
+            <l>list_files (main_path + '/robot_poses_json/', 'files', Files)</l>
+            <l>for j := 0 to |Files| - 1 by 1</l>
+            <c>    * Loading JSON from folder 'robot_poses_json'</c>
+            <l>    read_dict (main_path + '/robot_poses_json/robot_pose_'+ j +'.json', [], [], Dict)</l>
+            <c>    </c>
+            <c>    * Extracting 4×4 matrix</c>
+            <l>    MatTuple := Dict.['Data']</l>
+            <l>    Row0 := MatTuple.[0]</l>
+            <l>    Row1 := MatTuple.[1]</l>
+            <l>    Row2 := MatTuple.[2]</l>
+            <c>    </c>
+            <c>    * Filling HomMat3D (12 values)</c>
+            <l>    hom_mat3d_identity (H)</l>
+            <c>    </c>
+            <l>    for I := 0 to 3 by 1</l>
+            <l>        H[I]      := Row0.[I]</l>
+            <l>        H[4+I]    := Row1.[I]</l>
+            <l>        H[8+I]    := Row2.[I]</l>
+            <l>    endfor</l>
+            <c>    </c>
+            <c>    * Converting to halcon pose and saving</c>
+            <l>    hom_mat3d_to_pose (H, Pose)</l>
+            <l>    write_pose (Pose, main_path + '/robot_poses_halcon/robot_pose_'+ j +'.dat')</l>
+            <l>endfor</l>
+            <c/>
+        </body>
+        <docu id="main">
+            <parameters/>
+        </docu>
+    </procedure>
+</hdevelop>

--- a/source/Procedures/calc_calplate_pose_eye_in_hand.hdvp
+++ b/source/Procedures/calc_calplate_pose_eye_in_hand.hdvp
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hdevelop file_version="1.2" halcon_version="25.11.0.0">
+    <procedure name="calc_calplate_pose_eye_in_hand">
+        <interface>
+            <ic>
+                <par name="BaseToCalibrationObjectPose" base_type="ctrl" dimension="0"/>
+                <par name="CameraToEndEffectorPose" base_type="ctrl" dimension="0"/>
+                <par name="BaseToEndEffectorPose" base_type="ctrl" dimension="0"/>
+            </ic>
+            <oc>
+                <par name="CameraToCalibrationObjectPose" base_type="ctrl" dimension="0"/>
+            </oc>
+        </interface>
+        <body>
+            <c>*</c>
+            <c>* Calculate the pose of the calibration object in the camera frame for Eye-In-Hand.</c>
+            <c>*</c>
+            <c>* CameraToCalibrationObjectPose = cam_H_calplate</c>
+            <c>*                   = cam_H_tool * tool_H_base * base_H_calplate</c>
+            <c>*                   = CameraToEndEffectorPose * EndEffectorToBasePose * BaseToCalibrationObjectPose</c>
+            <l>pose_invert (BaseToEndEffectorPose, EndEffectorToBasePose)</l>
+            <l>pose_compose (CameraToEndEffectorPose, EndEffectorToBasePose, CameraToBasePose)</l>
+            <l>pose_compose (CameraToBasePose, BaseToCalibrationObjectPose, CameraToCalibrationObjectPose)</l>
+            <l>return ()</l>
+        </body>
+        <docu id="calc_calplate_pose_eye_in_hand">
+            <short lang="en_US">compute cam_H_calplate from hand-eye calibration results</short>
+            <parameters>
+                <parameter id="BaseToCalibrationObjectPose"/>
+                <parameter id="BaseToEndEffectorPose"/>
+                <parameter id="CameraToCalibrationObjectPose"/>
+                <parameter id="CameraToEndEffectorPose"/>
+            </parameters>
+        </docu>
+    </procedure>
+</hdevelop>

--- a/source/Procedures/calc_calplate_pose_eye_to_hand.hdvp
+++ b/source/Procedures/calc_calplate_pose_eye_to_hand.hdvp
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hdevelop file_version="1.2" halcon_version="25.11.0.0">
+    <procedure name="calc_calplate_pose_eye_to_hand">
+        <interface>
+            <ic>
+                <par name="EndEffectorToCalibrationObjectPose" base_type="ctrl" dimension="0"/>
+                <par name="CameraToBasePose" base_type="ctrl" dimension="0"/>
+                <par name="BaseToEndEffectorPose" base_type="ctrl" dimension="0"/>
+            </ic>
+            <oc>
+                <par name="CameraToCalibrationObjectPose" base_type="ctrl" dimension="0"/>
+            </oc>
+        </interface>
+        <body>
+            <c>*</c>
+            <c>* Calculate the pose of the calibration object in the camera frame for Eye-To-Hand.</c>
+            <c>*</c>
+            <c>* CameraToCalibrationObjectPose = cam_H_calplate </c>
+            <c>*                               = cam_H_base * base_H_tool * tool_H_calplate</c>
+            <c>*                               = BaseInCamPose*ToolInBasePose*CalObjInToolPose</c>
+            <l>pose_compose (CameraToBasePose, BaseToEndEffectorPose, CameraToEndEffectorPose)</l>
+            <l>pose_compose (CameraToEndEffectorPose, EndEffectorToCalibrationObjectPose, CameraToCalibrationObjectPose)</l>
+            <l>return ()</l>
+        </body>
+        <docu id="calc_calplate_pose_eye_to_hand">
+            <short lang="en_US">compute cam_H_calplate from hand-eye calibration results</short>
+            <parameters>
+                <parameter id="BaseToEndEffectorPose"/>
+                <parameter id="CameraToBasePose"/>
+                <parameter id="CameraToCalibrationObjectPose"/>
+                <parameter id="EndEffectorToCalibrationObjectPose"/>
+            </parameters>
+        </docu>
+    </procedure>
+</hdevelop>

--- a/source/Procedures/generate_R_G_B_and_RGB_images.hdvp
+++ b/source/Procedures/generate_R_G_B_and_RGB_images.hdvp
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hdevelop file_version="1.2" halcon_version="25.11.0.0">
+    <procedure name="generate_R_G_B_and_RGB_images">
+        <interface>
+            <io>
+                <par name="X" base_type="iconic" dimension="0"/>
+            </io>
+            <oo>
+                <par name="R" base_type="iconic" dimension="0"/>
+                <par name="G" base_type="iconic" dimension="0"/>
+                <par name="B" base_type="iconic" dimension="0"/>
+                <par name="RGB" base_type="iconic" dimension="0"/>
+            </oo>
+            <ic>
+                <par name="red" base_type="ctrl" dimension="0"/>
+                <par name="green" base_type="ctrl" dimension="0"/>
+                <par name="blue" base_type="ctrl" dimension="0"/>
+            </ic>
+        </interface>
+        <body>
+            <c>*</c>
+            <c>* Create separate images for each color channel and a combined RGB image.</c>
+            <c>*</c>
+            <l>get_image_size (X, Width, Height)</l>
+            <l>gen_image_const (R, 'real', Width, Height)</l>
+            <l>gen_image_const (G, 'real', Width, Height)</l>
+            <l>gen_image_const (B, 'real', Width, Height)</l>
+            <l>get_domain (R, Domain)</l>
+            <l>get_region_points (Domain, Rows, Columns)</l>
+            <l>set_grayval (R, Rows, Columns, red)</l>
+            <l>set_grayval (G, Rows, Columns, green)</l>
+            <l>set_grayval (B, Rows, Columns, blue)</l>
+            <l>compose3 (R, G, B, RGB)</l>
+            <l>return ()</l>
+        </body>
+        <docu id="generate_R_G_B_and_RGB_images">
+            <parameters>
+                <parameter id="B"/>
+                <parameter id="G"/>
+                <parameter id="R"/>
+                <parameter id="RGB"/>
+                <parameter id="X"/>
+                <parameter id="blue"/>
+                <parameter id="green"/>
+                <parameter id="red"/>
+            </parameters>
+        </docu>
+    </procedure>
+</hdevelop>

--- a/source/SampleUtils/convert_intrinsics_opencv_to_halcon.py
+++ b/source/SampleUtils/convert_intrinsics_opencv_to_halcon.py
@@ -1,5 +1,5 @@
 """
-Read Zivid camera intrinsic parameters (OpenCV model) from YML file or camera,
+Read Zivid camera intrinsic parameters (OpenCV model) from YML file, ZDF file or camera,
 convert them to internal camera parameters (Halcon model), and save them to .dat file.
 
 Example when reading from file: python convert_intrinsics_opencv_to_halcon.py
@@ -8,6 +8,9 @@ Example when reading from file: python convert_intrinsics_opencv_to_halcon.py
 
 Example when reading from camera with settings: python convert_intrinsics_opencv_to_halcon.py
          --input-settings Settings.yml --output-file "IntrinsicsHalcon"
+
+Example when reading from ZDF file: python convert_intrinsics_opencv_to_halcon.py
+         --input-zdf "frame.zdf" --output-file "IntrinsicsHalcon"
 
 Example when reading from camera without settings: python convert_intrinsics_opencv_to_halcon.py
          --output-file "IntrinsicsHalcon"
@@ -68,6 +71,23 @@ class CameraIntrinsics:
         from zivid.experimental import calibration
 
         intrinsics = calibration.intrinsics(camera, settings)
+        cx = intrinsics.camera_matrix.cx
+        cy = intrinsics.camera_matrix.cy
+        fx = intrinsics.camera_matrix.fx
+        fy = intrinsics.camera_matrix.fy
+        k1 = intrinsics.distortion.k1
+        k2 = intrinsics.distortion.k2
+        k3 = intrinsics.distortion.k3
+        p1 = intrinsics.distortion.p1
+        p2 = intrinsics.distortion.p2
+        return cls(cx, cy, fx, fy, k1, k2, k3, p1, p2)
+
+    @classmethod
+    def from_zdf(cls, frame):
+        # pylint: disable=import-outside-toplevel
+        from zivid.experimental import calibration
+
+        intrinsics = calibration.estimate_intrinsics(frame)
         cx = intrinsics.camera_matrix.cx
         cy = intrinsics.camera_matrix.cy
         fx = intrinsics.camera_matrix.fx
@@ -255,51 +275,72 @@ class CameraParameters:
         settings = zivid.Settings.load(settings_path) if settings_path else None
 
         intrinsics = CameraIntrinsics.from_camera(camera, settings)
-        if camera.info.model in (zivid.CameraInfo.Model.zivid3XL250):
+        pixel_size, image_size = cls.image_pixel_size(camera.info.model, settings.sampling.pixel if settings else None)
+
+        return cls(pixel_size, image_size, intrinsics)
+
+    @classmethod
+    def from_zdf(cls, zdf_filepath: Path):
+        # pylint: disable=import-outside-toplevel
+        import zivid
+
+        _ = zivid.Application()
+        frame = zivid.Frame(str(zdf_filepath))
+
+        intrinsics = CameraIntrinsics.from_zdf(frame)
+        pixel_size, image_size = cls.image_pixel_size(frame.camera_info.model, frame.settings.color.sampling.pixel)
+
+        return cls(pixel_size, image_size, intrinsics)
+
+    @classmethod
+    def image_pixel_size(cls, camera_model, sampling):
+        # pylint: disable=import-outside-toplevel
+        import zivid
+
+        if camera_model in (zivid.CameraInfo.Model.zivid3XL250):
             pixel_size = 5.48e-6
             image_size = np.array([np.int32(1408), np.int32(1408)])  # assume by2x2
-            if settings and settings.sampling.pixel == "all":
+            if sampling == "all":
                 pixel_size /= 2
                 image_size *= 2
-            elif settings and settings.sampling.pixel == "by4x4":
+            elif sampling == "by4x4":
                 pixel_size *= 2
                 image_size = (image_size / 2).astype(np.int32)
-        if camera.info.model in (
+        if camera_model in (
             zivid.CameraInfo.Model.zivid2PlusMR130,
             zivid.CameraInfo.Model.zivid2PlusMR60,
             zivid.CameraInfo.Model.zivid2PlusLR110,
         ):
             pixel_size = 5.48e-6
             image_size = np.array([np.int32(1224), np.int32(1024)])  # assume by2x2
-            if settings and settings.sampling.pixel == "all":
+            if sampling == "all":
                 pixel_size /= 2
                 image_size *= 2
-            elif settings and settings.sampling.pixel == "by4x4":
+            elif sampling == "by4x4":
                 pixel_size *= 2
                 image_size = (image_size / 2).astype(np.int32)
-        elif camera.info.model in (
+        elif camera_model in (
             zivid.CameraInfo.Model.zivid2PlusM130,
             zivid.CameraInfo.Model.zivid2PlusM60,
             zivid.CameraInfo.Model.zivid2PlusL110,
         ):
             pixel_size = 5.48e-6
             image_size = np.array([np.int32(1224), np.int32(1024)])
-            if settings and settings.sampling.pixel == "all":
+            if sampling == "all":
                 pixel_size /= 2
                 image_size *= 2
-            elif settings and settings.sampling.pixel in ("blueSubsample4x4", "redSubsample4x4"):
+            elif sampling in ("blueSubsample4x4", "redSubsample4x4"):
                 pixel_size *= 2
                 image_size = (image_size / 2).astype(np.int32)
-        elif camera.info.model in (zivid.CameraInfo.Model.zividTwo, zivid.CameraInfo.Model.zividTwoL100):
+        elif camera_model in (zivid.CameraInfo.Model.zividTwo, zivid.CameraInfo.Model.zividTwoL100):
             pixel_size = 4.50e-6
             image_size = np.array([np.int32(1944), np.int32(1200)])
-            if settings and settings.sampling.pixel in ("blueSubsample2x2", "redSubsample2x2"):
+            if sampling in ("blueSubsample2x2", "redSubsample2x2"):
                 pixel_size *= 2
                 image_size = (image_size / 2).astype(np.int32)
         else:
             raise RuntimeError("Unsupported camera model")
-
-        return cls(pixel_size, image_size, intrinsics)
+        return pixel_size, image_size
 
 
 def _cost_function(
@@ -376,6 +417,11 @@ def _args() -> argparse.Namespace:
         type=Path,
         help=("Path to Zivid capture settings to use for getting intrinsics from the camera as YML file."),
     )
+    group.add_argument(
+        "--input-zdf",
+        type=Path,
+        help=("Path to Zivid Data Format to use for getting intrinsics from the camera as zdf file."),
+    )
     parser.add_argument(
         "--model-name",
         type=str,
@@ -406,13 +452,15 @@ def _main():
     if args.input_intrinsics:
         print(f"Reading intrinsics from file '{args.input_intrinsics}'")
         camera_parameters = CameraParameters.from_file(args.input_intrinsics, args.model_name, args.pixels_to_sample)
+    elif args.input_zdf:
+        print(f"Reading intrinsics from ZDF file '{args.input_zdf}'")
+        camera_parameters = CameraParameters.from_zdf(args.input_zdf)
+    elif args.input_settings:
+        print("Reading intrinsics from camera with given settings")
+        camera_parameters = CameraParameters.from_camera(args.input_settings)
     else:
-        if args.input_settings:
-            print("Reading intrinsics from camera with given settings")
-            camera_parameters = CameraParameters.from_camera(args.input_settings)
-        else:
-            print("Reading intrinsics from camera with default settings")
-            camera_parameters = CameraParameters.from_camera()
+        print("Reading intrinsics from camera with default settings")
+        camera_parameters = CameraParameters.from_camera()
 
     halcon_internal_camera_parameters = _estimate_halcon_internal_camera_parameters_from_opencv(camera_parameters)
     halcon_internal_camera_parameters.write_to_dat_file(args.output_file)


### PR DESCRIPTION
## Summary

- Add Hand-Eye Calibration samples under `source/Applications/Advanced/HandEyeCalibration/`:
  - `EyeInHandCalibration3DObject.hdev` - Hand-eye calibration with a Zivid camera and a 3D calibration object
  - `EyeInHandCalibrationMVTecPlate.hdev` - Hand-eye calibration with a Zivid camera and MVTec calibration plate
  - `JSONHomogeneousMatrixToHalconPose.hdev` - Transform homogeneous matrices from JSON format to HALCON pose
- Add helper procedures to `source/Procedures/`:
  - `calc_calplate_pose_eye_in_hand.hdvp`
  - `calc_calplate_pose_eye_to_hand.hdvp`
  - `generate_R_G_B_and_RGB_images.hdvp`
- Update `convert_intrinsics_opencv_to_halcon.py` to add ZDF file support (`--input-zdf` argument)
- Update `README.md` with new samples and procedures